### PR TITLE
deal with JSON object overlay or openWindow is null

### DIFF
--- a/main.js
+++ b/main.js
@@ -1403,6 +1403,26 @@ class Tado extends utils.Adapter {
 						this.log.warn('Send this info to developer !!! { Unhandable information found in DoZoneState : ' + JSON.stringify(i) + ' with value : ' + JSON.stringify(ZonesState_data[i]));
 				}
 			} 
+			else {
+				switch (i){
+					case ('overlayType'):
+						this.log.debug('State to null for ' + state_root_states + '.' + i);
+						await this.setStateAsync(state_root_states + '.' + i, {val: null, ack: true});
+						break;
+					case ('overlay'):
+					case ('openWindow'):
+						if(ZonesState_data[i] == null) {
+							const states = await this.getStatesAsync(state_root_states + '.' + i + '.*');
+							for (const idS in states) {
+								this.log.debug('State to null for ' + idS);
+								//await this.setStateAsync(idS, {val: null, ack: true});
+								this.create_state(idS, idS.substr(idS.lastIndexOf('.') + 1, idS.length), null);
+							}
+						}
+						break;
+					default:
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
for discussion...
If JSON object 'overlay' or 'openWindow' is null the states are not updated (old values stay for a couple of minutes) until a kind of watchdog deletes the states.
This PR deals with this the NULL-body caused from JSON and sets all child-state-values to NULL

Caused by this the states are in sync to the TADO-system immediately.
This PR would also solve #24 